### PR TITLE
update original docker image to use chromedriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.4.1-node
+FROM circleci/ruby:2.4.1-node-browsers
 
 ADD circle/install_mecab.sh /home/circleci/install_mecab.sh
 


### PR DESCRIPTION
to use headless chrome for feature/system spec, we have to update original docker image.