### PR TITLE
Revert "update original docker image to use chromedriver"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.4.1-node-browsers
+FROM circleci/ruby:2.4.1-node
 
 ADD circle/install_mecab.sh /home/circleci/install_mecab.sh
 


### PR DESCRIPTION
Reverts 4ulc-team/ruby2.4.1_with_mecab#1